### PR TITLE
Alternative code for finalSurveyURLs which already have a query

### DIFF
--- a/landing_server/landing/submit/submitDB.py
+++ b/landing_server/landing/submit/submitDB.py
@@ -114,6 +114,8 @@ def redirectToSurvey(userid, token):
 			print e
 
     url = "%finalSurveyURL%/?uid="+userid+"&tok="+token+"&newtest=Y"
+    # use this line below if your survey url already consists a query
+    # url = "%finalSurveyURL%&uid="+userid+"&tok="+token
     if(not (url.startswith("http://") or url.startswith("https://"))):
         url = "https://" + url
     return redirect(url, code=302)


### PR DESCRIPTION
The finalSurveyURLs handling did not work because my survey url already had a query, so I added an optional line.